### PR TITLE
[fix] add missing id from custom field template

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -340,7 +340,7 @@ class actorExportDialog extends FormApplication {
                             );
                         } else {
                             module.mapper.download(undefined, undefined, function () {
-                                actorExport.providerFileProgress(document.getElementById('field._custom_._custom'));
+                                actorExport.providerFileProgress(document.getElementById('field._custom_._custom_'));
                             });
                         }
                     })

--- a/templates/actor-export.hbs
+++ b/templates/actor-export.hbs
@@ -16,7 +16,7 @@
 {{/each}}
 {{#if customProvider}}
         <h2 class="category-title">Custom Provider <i class="fa fa-question-circle" aria-hidden="true"></i></h2>
-        <div class="form-group">
+        <div class="form-group" id="field._custom_._custom_">
             <label for="_custom_._custom_">Custom Provider</label>
             <div class="form-fields">
                 <input type="checkbox" data-provider="_custom_" data-file="_custom_" name="_custom_" id="_custom_._custom_" data-dtype="Boolean" />


### PR DESCRIPTION
At present, following the addition of an "in progress" spinner, the Custom provider always fails because the user-facing UI field is missing a tag ID. Additionally, the custom field ID name is missing a terminal underscore in one location. This fixes both issues and makes custom providers work again.