### PR TITLE
Feature: override PDF font as a per user setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,4 @@ tmp
 **sh
 **_autosave_**
 node_modules
-fonts/**.ttf
-fonts/**.otf
+fonts/**.org.ttf

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,7 @@
 # Ignore certain libraries
 scripts/lib/FileSaver.js
+scripts/lib/providers/fontkit.es.js
+scripts/lib/providers/pako.esm.mjs
 scripts/lib/providers/pdf-lib.esm.js
 scripts/lib/providers/pdf-lib.esm.js.map
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [CalVer](https://calver.org/about.html) versioning.
 
+## [unreleased]
+
+### Added
+
+- Functionality to override the font used in PDFs ([Feature 13](https://github.com/bushvin/actor-export/issues/13)).
+  Go to *Game Settings* >> *Configure Settings* >> toggle **Override PDF fonts** and select **Override PDF font selection**
+
 ## [2024.11.2] - 2024-11-13
 
 ### Added

--- a/languages/en.json
+++ b/languages/en.json
@@ -1,43 +1,5 @@
 {
     "ACTOR-EXPORT": {
-        "settings": {
-            "actorExportProviderDialog": {
-                "title": "Export Providers"
-            },
-            "actorExportCustomProvider": {
-                "title": "Custom Provider"
-            },
-            "allProviders": {
-                "name": "All Providers",
-                "hint": "All Providers"
-            },
-            "exportProviderCustom": {
-                "name": "Custom Export Provider",
-                "hint": "Custom Javascript code to generate a single download",
-                "label": "Custom Provider"
-            },
-            "exportProviderFilter": {
-                "name": "Select Actor Export Providers",
-                "hint": "Allows you to limit the Actor Export Providers for non-Gamemaster users",
-                "label": "Filter Providers"
-            },
-            "exportProviderCustomCode": {
-                "name": "Custom Provider Javascript code",
-                "hint": "Custom Javascript code to generate a single download"
-            },
-            "exportSelectedProviderFiles": {
-                "name": "Selected Provider Files",
-                "hint": "The list of selected Provider files to export"
-            },
-            "enabledProviders": {
-                "name": "Enabled Providers",
-                "hint": "Providers enabled by your Gamemaster"
-            },
-            "relationProvider": {
-                "name": "Relation Provider Selector",
-                "hint": "Select the provider to translate actor data into a file"
-            }
-        },
         "actor-dialog": {
             "header-button": {
                 "label": "Export"
@@ -45,6 +7,52 @@
         },
         "export-dialog": {
             "title": "Export Actor"
+        },
+        "settings": {
+            "actorExportCustomProvider": {
+                "title": "Custom Provider"
+            },
+            "actorExportProviderDialog": {
+                "title": "Export Providers"
+            },
+            "allProviders": {
+                "name": "All Providers",
+                "hint": "All Providers"
+            },
+            "enabledProviders": {
+                "name": "Enabled Providers",
+                "hint": "Providers enabled by your Gamemaster"
+            },
+            "exportProviderCustom": {
+                "name": "Custom Export Provider",
+                "hint": "Custom Javascript code to generate a single download",
+                "label": "Custom Provider"
+            },
+            "exportProviderCustomCode": {
+                "name": "Custom Provider Javascript code",
+                "hint": "Custom Javascript code to generate a single download"
+            },
+            "exportProviderFilter": {
+                "name": "Select Actor Export Providers",
+                "hint": "Allows you to limit the Actor Export Providers for non-Gamemaster users",
+                "label": "Filter Providers"
+            },
+            "exportProviderOverridePdfFonts": {
+                "name": "Override PDF fonts",
+                "hint": "Override PDF fonts with a safe font. The resulting PDF may not generate correctly, as it may not be optimized for the selected font!"
+            },
+            "exportProviderOverridePdfFontsSelection": {
+                "name": "Override PDF font selection",
+                "hint": "Select the font to use to override"
+            },
+            "exportSelectedProviderFiles": {
+                "name": "Selected Provider Files",
+                "hint": "The list of selected Provider files to export"
+            },
+            "relationProvider": {
+                "name": "Relation Provider Selector",
+                "hint": "Select the provider to translate actor data into a file"
+            }
         }
     }
 }

--- a/providers/pf2e-black-book-editions/provider.js
+++ b/providers/pf2e-black-book-editions/provider.js
@@ -39,6 +39,7 @@ const action_8 = {
     size: 8,
     lineHeight: 8,
     color: '#01579b',
+    overrideFont: false,
 };
 const action_8_right = { ...action_8, ...{ halign: 'right' } };
 

--- a/providers/pf2e-remaster-bushvin/provider.js
+++ b/providers/pf2e-remaster-bushvin/provider.js
@@ -37,6 +37,7 @@ const action_8 = {
     size: 8,
     lineHeight: 8,
     color: '#01579b',
+    overrideFont: false,
 };
 const action_8_right = { ...action_8, ...{ halign: 'right' } };
 

--- a/providers/pf2e-remaster-paizo/provider.js
+++ b/providers/pf2e-remaster-paizo/provider.js
@@ -37,6 +37,7 @@ const action_8 = {
     size: 8,
     lineHeight: 8,
     color: '#01579b',
+    overrideFont: false,
 };
 const action_8_right = { ...action_8, ...{ halign: 'right' } };
 

--- a/scripts/lib/providers/BaseProvider.js
+++ b/scripts/lib/providers/BaseProvider.js
@@ -1,3 +1,4 @@
+import { actorExport } from '../../main.js';
 /**
  * BaseProvider module
  * This module should be used as the basis for new providers
@@ -37,10 +38,12 @@ export class providerError extends Error {
  */
 export class baseProvider {
     constructor(actor) {
+        this._moduleID = actorExport.ID;
+        this._moduleSettings = actorExport.SETTINGS;
         this.actor = actor;
         this.actorName = this.actor.name || '';
         this.customProviderFile = undefined;
-        this.logPrefix = 'actor-export';
+        this.logPrefix = this._moduleID;
         this.providerRootPath = undefined;
         this.providerFilePath = undefined;
         this.providerDestinationFileName = undefined;

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -6,7 +6,7 @@ import './lib/FileSaver.js';
  * @class
  * Class to contain all relevant information and functions for the module
  */
-class actorExport {
+export class actorExport {
     static ID = 'actor-export';
     static SETTINGS = {
         ALL_PROVIDERS: 'allProviders',
@@ -14,6 +14,8 @@ class actorExport {
         PROVIDER_FILTER: 'exportProviderFilter',
         PROVIDER_CUSTOM: 'exportProviderCustom',
         PROVIDER_CUSTOM_CODE: 'exportProviderCustomCode',
+        PROVIDER_OVERRIDE_PDF_FONTS: 'exportProviderOverridePdfFonts',
+        PROVIDER_OVERRIDE_PDF_FONTS_SELECTION: 'exportProviderOverridePdfFontsSelection',
         SELECTED_PROVIDER_FILES: 'exportSelectedProviderFiles',
     };
     static TEMPLATES = {
@@ -69,6 +71,44 @@ class actorExport {
             type: actorExportCustomProvider,
             restricted: true,
             requiresReload: true,
+        });
+
+        game.settings.register(this.ID, this.SETTINGS.PROVIDER_OVERRIDE_PDF_FONTS, {
+            name: `ACTOR-EXPORT.settings.${this.SETTINGS.PROVIDER_OVERRIDE_PDF_FONTS}.name`,
+            hint: `ACTOR-EXPORT.settings.${this.SETTINGS.PROVIDER_OVERRIDE_PDF_FONTS}.hint`,
+            scope: 'client',
+            config: true,
+            type: Boolean,
+            restricted: false,
+            requiresReload: false,
+            default: false,
+        });
+
+        game.settings.register(this.ID, this.SETTINGS.PROVIDER_OVERRIDE_PDF_FONTS_SELECTION, {
+            name: `ACTOR-EXPORT.settings.${this.SETTINGS.PROVIDER_OVERRIDE_PDF_FONTS_SELECTION}.name`,
+            hint: `ACTOR-EXPORT.settings.${this.SETTINGS.PROVIDER_OVERRIDE_PDF_FONTS_SELECTION}.hint`,
+            scope: 'client',
+            config: true,
+            type: String,
+            choices: {
+                Courier: 'Courier',
+                CourierBold: 'Courier Bold',
+                CourierOblique: 'Courier Oblique',
+                CourierBoldOblique: 'Courier Bold Oblique',
+                Helvetica: 'Helvetica',
+                HelveticaBold: 'Helvetica Bold',
+                HelveticaOblique: 'Helvetica Oblique',
+                HelveticaBoldOblique: 'Helvetica Bold Oblique',
+                TimesRoman: 'Times Roman',
+                TimesRomanBold: 'Times Roman Bold',
+                TimesRomanItalic: 'Times Roman Italic',
+                TimesRomanBoldItalic: 'Times Roman Bold Italic',
+                Symbol: 'Symbol',
+                ZapfDingbats: 'Zapf Dingbats',
+            },
+            restricted: false,
+            requiresReload: false,
+            default: 'Helvetica',
         });
 
         game.settings.register(this.ID, this.SETTINGS.ALL_PROVIDERS, {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -65,7 +65,7 @@ class actorExport {
             name: `ACTOR-EXPORT.settings.${this.SETTINGS.PROVIDER_CUSTOM}.name`,
             label: `ACTOR-EXPORT.settings.${this.SETTINGS.PROVIDER_CUSTOM}.label`,
             hint: `ACTOR-EXPORT.settings.${this.SETTINGS.PROVIDER_CUSTOM}.hint`,
-            icon: `fa fa-file-code-o`,
+            icon: `fa fa-file-code`,
             type: actorExportCustomProvider,
             restricted: true,
             requiresReload: true,


### PR DESCRIPTION
this PR provides the necessary functionality to allow for overriding the fonts in a PDF export.
This is a per-user setting, not a global setting, so each user can have their own preference.

Go to *Game Settings* >> *Configure Settings* >> toggle **Override PDF fonts** and select **Override PDF font selection**