### PR TITLE
Fix NPC strike undefined sneak attack damage

### DIFF
--- a/scripts/lib/providers/ScribeProvider.js
+++ b/scripts/lib/providers/ScribeProvider.js
@@ -245,7 +245,7 @@ class scribeCharacterStrike extends scribeBase {
         }
         scribify.push('**Damage**');
         let dmg = await this._strike.damageFormula;
-        if (this._strike.sneakAttackDamage !== '') {
+        if (this._strike.sneakAttackDamage !== undefined) {
             dmg = `${dmg} *(+${this._strike.sneakAttackDamage} sneak attack damage)*`;
         }
         scribify.push(dmg);


### PR DESCRIPTION
Fixes scribe export of NPC actors having `*(+undefined sneak attack damage)*` appended to each strike's damage.