### PR TITLE
[5e] Rework skill export

### DIFF
--- a/providers/dnd5e/provider.js
+++ b/providers/dnd5e/provider.js
@@ -83,10 +83,11 @@ const proficiencyBonus = dnd5eHelper.quantifyNumber(character.proficiencyBonus);
 mapper.textBox('inspiration', fileNames, 0, 95, 130, 25, 19, hasInspiration, mf_12_centered_middle);
 mapper.textBox('proficiency bonus', fileNames, 0, 95, 165, 25, 25, proficiencyBonus, mf_17_centered_middle);
 
-// skills
-let skillsY = [316, 328, 343, 356, 370, 383, 397, 410, 424, 437, 451, 464, 478, 491, 505, 518, 532, 545];
+// skills      acr  ani  arc  ath  dec  his  ins  inv  itm  med  nat  per  prc  prf  rel  slt  ste  sur
+// english     acr  ani  arc  ath  dec  his  ins  itm  inv  med  nat  prc  prf  per  rel  slt  ste  sur
+let skillsY = [316, 328, 343, 356, 370, 383, 397, 424, 410, 437, 451, 491, 464, 478, 505, 518, 532, 545];
 Object.values(character.skills)
-    .sort((a, b) => a.label.localeCompare(b.label))
+    .sort((a, b) => a.slug.localeCompare(b.slug))
     .forEach((s) => {
         let skillY;
         if (skillsY.length > 0) {
@@ -388,11 +389,12 @@ Object.values(character.abilities).forEach((a) => {
 mapper.textBox('inspiration', fileNames, 0, 92, 126, 25, 19, hasInspiration, mf_12_centered_middle);
 mapper.textBox('proficiency bonus', fileNames, 0, 92, 160, 25, 24, proficiencyBonus, mf_17_centered_middle);
 
-// skills
-skillsY = [306, 320, 333, 346, 359, 372, 385, 398, 411, 424, 438, 451, 464, 477, 490, 503, 516, 529];
+// skills  acr  ani  arc  ath  dec  his  ins  inv  itm  med  nat  per  prc  prf  rel  slt  ste  sur
+// portug  acr  arc  ath  prf  dec  ste  his  itm  ins  inv  ani  med  nat  prc  per  slt  rel  sur
+skillsY = [306, 438, 320, 333, 359, 385, 411, 424, 398, 451, 464, 490, 477, 346, 516, 503, 372, 529];
 
 Object.values(character.skills)
-    .sort((a, b) => a.label.localeCompare(b.label))
+    .sort((a, b) => a.slug.localeCompare(b.slug))
     .forEach((s) => {
         let skillY;
         if (skillsY.length > 0) {
@@ -632,10 +634,11 @@ Object.values(character.abilities).forEach((a) => {
 mapper.textBox('inspiration', fileNames, 0, 88, 144, 25, 19, hasInspiration, mf_12_centered_middle);
 mapper.textBox('proficiency bonus', fileNames, 0, 88, 179, 25, 24, proficiencyBonus, mf_17_centered_middle);
 
-// skills
-skillsY = [330, 344, 357, 371, 384, 398, 411, 425, 438, 452, 465, 479, 492, 506, 519, 533, 546, 560];
+// skills  acr  ani  arc  ath  dec  his  ins  inv  itm  med  nat  per  prc  prf  rel  slt  ste  sur
+// german  acr  arc  ath  prf  itm  slt  his  med  ste  ani  ins  inv  nat  rel  dec  sur  per  prc
+skillsY = [330, 452, 344, 357, 519, 411, 465, 479, 384, 425, 492, 546, 560, 371, 506, 398, 438, 533];
 Object.values(character.skills)
-    .sort((a, b) => a.label.localeCompare(b.label))
+    .sort((a, b) => a.slug.localeCompare(b.slug))
     .forEach((s) => {
         let skillY;
         if (skillsY.length > 0) {

--- a/providers/dnd5e/provider.js
+++ b/providers/dnd5e/provider.js
@@ -88,19 +88,13 @@ mapper.textBox('proficiency bonus', fileNames, 0, 95, 165, 25, 25, proficiencyBo
 let skillsY = [316, 328, 343, 356, 370, 383, 397, 424, 410, 437, 451, 491, 464, 478, 505, 518, 532, 545];
 Object.values(character.skills)
     .sort((a, b) => a.slug.localeCompare(b.slug))
-    .forEach((s) => {
-        let skillY;
-        if (skillsY.length > 0) {
-            skillY = skillsY[0];
-            skillsY.shift();
-        }
-        if (typeof skillY !== 'undefined') {
-            ref = `${s.label} skill`;
-            const isProficient = dnd5eHelper.evalCheckMark(s.isProficient);
-            const skillModifier = dnd5eHelper.quantifyNumber(s.modifier);
-            mapper.textBox(ref, fileNames, 0, 101, skillY + 5, 7, 10, isProficient, mf_8_centered);
-            mapper.textBox(ref, fileNames, 0, 111, skillY, 16, 14, skillModifier, mf_12_centered);
-        }
+    .forEach((s, idx) => {
+        let skillY = skillsY[idx];
+        ref = `${s.label} skill`;
+        const isProficient = dnd5eHelper.evalCheckMark(s.isProficient);
+        const skillModifier = dnd5eHelper.quantifyNumber(s.modifier);
+        mapper.textBox(ref, fileNames, 0, 101, skillY + 5, 7, 10, isProficient, mf_8_centered);
+        mapper.textBox(ref, fileNames, 0, 111, skillY, 16, 14, skillModifier, mf_12_centered);
     });
 
 // AC
@@ -395,19 +389,13 @@ skillsY = [306, 438, 320, 333, 359, 385, 411, 424, 398, 451, 464, 490, 477, 346,
 
 Object.values(character.skills)
     .sort((a, b) => a.slug.localeCompare(b.slug))
-    .forEach((s) => {
-        let skillY;
-        if (skillsY.length > 0) {
-            skillY = skillsY[0];
-            skillsY.shift();
-        }
-        if (typeof skillY !== 'undefined') {
+    .forEach((s, idx) => {
+            let skillY = skillsY[idx];
             ref = `${s.label} skill`;
             const isProficient = dnd5eHelper.evalCheckMark(s.isProficient);
             const skillModifier = dnd5eHelper.quantifyNumber(s.modifier);
             mapper.textBox(ref, fileNames, 0, 98, skillY + 3, 7, 10, isProficient, mf_8_centered);
             mapper.textBox(ref, fileNames, 0, 109, skillY, 14, 14, skillModifier, mf_12_centered);
-        }
     });
 
 // AC
@@ -639,19 +627,13 @@ mapper.textBox('proficiency bonus', fileNames, 0, 88, 179, 25, 24, proficiencyBo
 skillsY = [330, 452, 344, 357, 519, 411, 465, 479, 384, 425, 492, 546, 560, 371, 506, 398, 438, 533];
 Object.values(character.skills)
     .sort((a, b) => a.slug.localeCompare(b.slug))
-    .forEach((s) => {
-        let skillY;
-        if (skillsY.length > 0) {
-            skillY = skillsY[0];
-            skillsY.shift();
-        }
-        if (typeof skillY !== 'undefined') {
-            ref = `${s.label} skill`;
-            const isProficient = dnd5eHelper.evalCheckMark(s.isProficient);
-            const skillModifier = dnd5eHelper.quantifyNumber(s.modifier);
-            mapper.textBox(ref, fileNames, 0, 94, skillY + 3, 7, 10, isProficient, mf_8_centered);
-            mapper.textBox(ref, fileNames, 0, 105, skillY, 14, 14, skillModifier, mf_12_centered);
-        }
+    .forEach((s, idx) => {
+        let skillY = skillsY[idx];
+        ref = `${s.label} skill`;
+        const isProficient = dnd5eHelper.evalCheckMark(s.isProficient);
+        const skillModifier = dnd5eHelper.quantifyNumber(s.modifier);
+        mapper.textBox(ref, fileNames, 0, 94, skillY + 3, 7, 10, isProficient, mf_8_centered);
+        mapper.textBox(ref, fileNames, 0, 105, skillY, 14, 14, skillModifier, mf_12_centered);
     });
 
 // AC

--- a/providers/dnd5e/provider.js
+++ b/providers/dnd5e/provider.js
@@ -35,6 +35,26 @@ const f_debug = { debug: true };
 let ref;
 let fileNames;
 
+/**
+ * Prints the skills to the sheet in the given order
+ *
+ * @param skills {number[]} the character's skills
+ * @param verticalPositioning {number[]} the vertical offset for each skill as an array. With this parameter, you can control the skill ordering.
+ * @param horizontalPositioning {number} the horizontal offset of the skills box
+ */
+function printSkills(skills, verticalPositioning, horizontalPositioning) {
+    Object.values(skills)
+        .sort((a, b) => a.slug.localeCompare(b.slug))
+        .forEach((skill, idx) => {
+            const skillY = verticalPositioning[idx];
+            const ref = `${skill.label} skill`;
+            const isProficient = dnd5eHelper.evalCheckMark(skill.isProficient);
+            const skillModifier = dnd5eHelper.quantifyNumber(skill.modifier);
+            mapper.textBox(ref, fileNames, 0, horizontalPositioning, skillY + 3, 7, 10, isProficient, mf_8_centered);
+            mapper.textBox(ref, fileNames, 0, horizontalPositioning + 10, skillY, 16, 14, skillModifier, mf_12_centered);
+        });
+}
+
 const character = dnd5eHelper.getActorObject(game, actor);
 mapper.pdfTitle = character.name;
 
@@ -86,16 +106,7 @@ mapper.textBox('proficiency bonus', fileNames, 0, 95, 165, 25, 25, proficiencyBo
 // skills      acr  ani  arc  ath  dec  his  ins  inv  itm  med  nat  per  prc  prf  rel  slt  ste  sur
 // english     acr  ani  arc  ath  dec  his  ins  itm  inv  med  nat  prc  prf  per  rel  slt  ste  sur
 let skillsY = [316, 328, 343, 356, 370, 383, 397, 424, 410, 437, 451, 491, 464, 478, 505, 518, 532, 545];
-Object.values(character.skills)
-    .sort((a, b) => a.slug.localeCompare(b.slug))
-    .forEach((s, idx) => {
-        let skillY = skillsY[idx];
-        ref = `${s.label} skill`;
-        const isProficient = dnd5eHelper.evalCheckMark(s.isProficient);
-        const skillModifier = dnd5eHelper.quantifyNumber(s.modifier);
-        mapper.textBox(ref, fileNames, 0, 101, skillY + 5, 7, 10, isProficient, mf_8_centered);
-        mapper.textBox(ref, fileNames, 0, 111, skillY, 16, 14, skillModifier, mf_12_centered);
-    });
+printSkills(character.skills, skillsY, 101);
 
 // AC
 ref = 'AC';
@@ -386,17 +397,7 @@ mapper.textBox('proficiency bonus', fileNames, 0, 92, 160, 25, 24, proficiencyBo
 // skills  acr  ani  arc  ath  dec  his  ins  inv  itm  med  nat  per  prc  prf  rel  slt  ste  sur
 // portug  acr  arc  ath  prf  dec  ste  his  itm  ins  inv  ani  med  nat  prc  per  slt  rel  sur
 skillsY = [306, 438, 320, 333, 359, 385, 411, 424, 398, 451, 464, 490, 477, 346, 516, 503, 372, 529];
-
-Object.values(character.skills)
-    .sort((a, b) => a.slug.localeCompare(b.slug))
-    .forEach((s, idx) => {
-            let skillY = skillsY[idx];
-            ref = `${s.label} skill`;
-            const isProficient = dnd5eHelper.evalCheckMark(s.isProficient);
-            const skillModifier = dnd5eHelper.quantifyNumber(s.modifier);
-            mapper.textBox(ref, fileNames, 0, 98, skillY + 3, 7, 10, isProficient, mf_8_centered);
-            mapper.textBox(ref, fileNames, 0, 109, skillY, 14, 14, skillModifier, mf_12_centered);
-    });
+printSkills(character.skills, skillsY, 98);
 
 // AC
 ref = 'AC';
@@ -625,16 +626,7 @@ mapper.textBox('proficiency bonus', fileNames, 0, 88, 179, 25, 24, proficiencyBo
 // skills  acr  ani  arc  ath  dec  his  ins  inv  itm  med  nat  per  prc  prf  rel  slt  ste  sur
 // german  acr  arc  ath  prf  itm  slt  his  med  ste  ani  ins  inv  nat  rel  dec  sur  per  prc
 skillsY = [330, 452, 344, 357, 519, 411, 465, 479, 384, 425, 492, 546, 560, 371, 506, 398, 438, 533];
-Object.values(character.skills)
-    .sort((a, b) => a.slug.localeCompare(b.slug))
-    .forEach((s, idx) => {
-        let skillY = skillsY[idx];
-        ref = `${s.label} skill`;
-        const isProficient = dnd5eHelper.evalCheckMark(s.isProficient);
-        const skillModifier = dnd5eHelper.quantifyNumber(s.modifier);
-        mapper.textBox(ref, fileNames, 0, 94, skillY + 3, 7, 10, isProficient, mf_8_centered);
-        mapper.textBox(ref, fileNames, 0, 105, skillY, 14, 14, skillModifier, mf_12_centered);
-    });
+printSkills(character.skills, skillsY, 94);
 
 // AC
 ref = 'AC';


### PR DESCRIPTION
As promised earlier (#17), I had an idea about improving the skill export. I split this into three commits, and I recommend reviewing commit-wise for an easier understanding of the changes:

1. This is the main contribution from a functional side. It makes the export order of the skills separate from the foundry language setting. This allows e.g. the export of a German sheet from a foundry with the language set to English (and all other combinations). The exported text will still be in English, but the numbers will no longer go to the wrong boxes. I had some difficulties with the Portuguese sheet as I'm neither a Portuguese nor a Spanish speaker, but I tried my best, and my tests indicate the skill order should be correct. I could not do a regression test because I could not find a Portuguese language module for 5e.
2. Minor code rework that removes unneeded checks that bulk the code
3. Extract the skill-export code as a function. This makes the code more brief. I did some pixel adjustments to avoid excessive parameters. Looking at the generated PDF, it seems like an improvement.

If you are not happy with some of the changes, let me know and I can remove them from the PR