### PR TITLE
fix: gracefully resolve formulas when they are unknown to FVTT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [CalVer](https://calver.org/about.html) versioning.
 
+## [unreleased]
+
+## Fixed
+
+- `pf2ePlayer.pf2eActor.knownFormulas` threw an error when a formula is non-exitant, probably because it is a custom one.
+
 ## [2025.4.1] - 2025-04-22
 
 ## Changed

--- a/scripts/lib/helpers/PF2eHelper.js
+++ b/scripts/lib/helpers/PF2eHelper.js
@@ -1980,13 +1980,24 @@ export class pf2ePlayer extends pf2eActor {
         try {
             this.actor.system.crafting.formulas.forEach((f) => {
                 const el = fromUuidSync(f.uuid);
-                knownFormulas.push({
-                    name: el.name,
-                    level: el.system.level.value,
-                    description: el.system.description.value,
-                    traits: [el.system.traits.rarity].concat(el.system.traits.value),
-                    cost: formulaCost[el.system.level.value],
-                });
+                if (el !== null) {
+                    knownFormulas.push({
+                        name: el.name,
+                        level: el.system.level.value,
+                        description: el.system.description.value,
+                        traits: [el.system.traits.rarity].concat(el.system.traits.value),
+                        cost: formulaCost[el.system.level.value],
+                    });
+                } else {
+                    knownFormulas.push({
+                        name: 'Unknown Formula',
+                        level: 0,
+                        description:
+                            'This is probably a custom formula, which is not available in any of the compendiums in your instance of FoundryVTT',
+                        traits: [],
+                        cost: '',
+                    });
+                }
             });
         } catch (error) {
             throw new pf2eActorPropertyError('actor-export', 'pf2eActor', 'knownFormulas', error.message);


### PR DESCRIPTION
This fix resolves an error which occurs when a formula is unknown in the compendiums. 
Instead of throwing an error, it will ad an "unknown formula" to the list